### PR TITLE
Spells now created in CastSpell.cs - prevents unwanted cast animations

### DIFF
--- a/Assets/unityProject.unity
+++ b/Assets/unityProject.unity
@@ -290,6 +290,52 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &416878040
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4727386271784798, guid: 7279a4900f3bcb44f8bc16cf957e0158, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 12.33
+      objectReference: {fileID: 0}
+    - target: {fileID: 4727386271784798, guid: 7279a4900f3bcb44f8bc16cf957e0158, type: 2}
+      propertyPath: m_LocalPosition.y
+      value: 1.05
+      objectReference: {fileID: 0}
+    - target: {fileID: 4727386271784798, guid: 7279a4900f3bcb44f8bc16cf957e0158, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4727386271784798, guid: 7279a4900f3bcb44f8bc16cf957e0158, type: 2}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4727386271784798, guid: 7279a4900f3bcb44f8bc16cf957e0158, type: 2}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4727386271784798, guid: 7279a4900f3bcb44f8bc16cf957e0158, type: 2}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4727386271784798, guid: 7279a4900f3bcb44f8bc16cf957e0158, type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4727386271784798, guid: 7279a4900f3bcb44f8bc16cf957e0158, type: 2}
+      propertyPath: m_RootOrder
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 1018614953532254, guid: 7279a4900f3bcb44f8bc16cf957e0158, type: 2}
+      propertyPath: m_Name
+      value: Unit1 (1)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: 7279a4900f3bcb44f8bc16cf957e0158, type: 2}
+  m_IsPrefabParent: 0
 --- !u!1001 &486806111
 Prefab:
   m_ObjectHideFlags: 0

--- a/Assets/unityProject/Scripts/Ability Scripts/Abilities.cs
+++ b/Assets/unityProject/Scripts/Ability Scripts/Abilities.cs
@@ -257,32 +257,4 @@ public class Abilities : MonoBehaviour
 
     }
 
-
-    //methods to apply different spell effects on a target - these are your spells
-    public void ability1(CharacterStatus target)
-    {
-        castAbility(target, 3, 0, 3, (float).5, 0, 0, false);
-    }
-
-
-    public void ability2(CharacterStatus target)
-    {
-        castAbility(target, 3, 0, 3, (float).5, 0, 0, false);
-    }
-
-    public void ability3(CharacterStatus target)
-    {
-        castAbility(target, 0, 3, 3, 0, 0, 0, false);
-    }
-
-    public void ability4(CharacterStatus target)
-    {
-        castAbility(target, 3, 0, 3, (float).5, 0, 0, false);
-    }
-
-    public void ability5(CharacterStatus target)
-    {
-        castAbility(target, 3, 0, 3, (float).5, 0, 0, false);
-    }
-
 }

--- a/Assets/unityProject/Scripts/Ability Scripts/CastSpell.cs
+++ b/Assets/unityProject/Scripts/Ability Scripts/CastSpell.cs
@@ -88,33 +88,41 @@ public class CastSpell : MonoBehaviour
         //check if spell moves towards and applies effect upon reaching target
         if (spellMoves)
         {
-            //create spell effect on the castors position and ignore collisions with the caster so it does not instantly detonate
-            Vector3 startPos = new Vector3(_caster.transform.position.x, _caster.transform.position.y + (float).5, _caster.transform.position.z);
-            currentAnimation = Instantiate(abilityAnimation, _caster.transform.position, Quaternion.identity);
-            Physics.IgnoreCollision(currentAnimation.GetComponent<Collider>(), gameObject.GetComponentInParent<Collider>());
+            //check if we have enough ap to cast the ability
+            if (canCast(abilityNum))
+            {
+                //create spell effect on the castors position and ignore collisions with the caster so it does not instantly detonate
+                Vector3 startPos = new Vector3(_caster.transform.position.x, _caster.transform.position.y + (float).5, _caster.transform.position.z);
+                currentAnimation = Instantiate(abilityAnimation, _caster.transform.position, Quaternion.identity);
+                Physics.IgnoreCollision(currentAnimation.GetComponent<Collider>(), gameObject.GetComponentInParent<Collider>());
 
-            //rotate the spell in the direction of the target
-            float rotation = getRotation(target);
-            currentAnimation.transform.eulerAngles = new Vector3(currentAnimation.transform.eulerAngles.x,
-                rotation + abilityAnimation.transform.eulerAngles.y, currentAnimation.transform.eulerAngles.z);
+                //rotate the spell in the direction of the target
+                float rotation = getRotation(target);
+                currentAnimation.transform.eulerAngles = new Vector3(currentAnimation.transform.eulerAngles.x,
+                    rotation + abilityAnimation.transform.eulerAngles.y, currentAnimation.transform.eulerAngles.z);
 
-            //find the direction of target
-            Vector3 targetDirection = (target.transform.position - _caster.transform.position).normalized;
+                //find the direction of target
+                Vector3 targetDirection = (target.transform.position - _caster.transform.position).normalized;
 
-            //accelerate the spell animation towards the target
-            currentAnimation.GetComponent<Rigidbody>().AddForce(targetDirection * 1000);
+                //accelerate the spell animation towards the target
+                currentAnimation.GetComponent<Rigidbody>().AddForce(targetDirection * 1000);
+            }
         }
         //this spell appears on the targets location
         else
         {
-            //create spell effect on the target location
-            currentAnimation = Instantiate(abilityAnimation, target.transform.position, Quaternion.identity);
-            currentAnimation.transform.position = new Vector3(currentAnimation.transform.position.x, 0, currentAnimation.transform.position.z);
+            //check if we have enough ap to cast the ability
+            if (canCast(abilityNum))
+            {
+                //create spell effect on the target location
+                currentAnimation = Instantiate(abilityAnimation, target.transform.position, Quaternion.identity);
+                currentAnimation.transform.position = new Vector3(currentAnimation.transform.position.x, 0, currentAnimation.transform.position.z);
 
-            //as the spell is at the target immediately apply appropriate spell effect
-            //from the abilities class
-            applyAbilityEffect(abilityNum);
+                //as the spell is at the target immediately apply appropriate spell effect
+                //from the abilities class
 
+                applyAbilityEffect(abilityNum);
+            }
         }
     }
 
@@ -173,30 +181,94 @@ public class CastSpell : MonoBehaviour
 
     }
 
+    //applies the spell effect to the target
     public void applyAbilityEffect(int abilityUsed)
     {
 
         if (abilityUsed == 1)
         {
-            _caster.ability1(spellTarget);
+            _caster.castAbility(spellTarget, 3, 0, 3, 0, (float).5, 0, true);
         }
         else if (abilityUsed == 2)
         {
-            _caster.ability2(spellTarget);
+            _caster.castAbility(spellTarget, 7, 0, 6, 0, 0, 0, true);
         }
         else if (abilityUsed == 3)
         {
-            _caster.ability3(spellTarget);
+            _caster.castAbility(spellTarget, 0, 5, 5, 0, 0, 0, true);
         }
         else if (abilityUsed == 4)
         {
-            _caster.ability4(spellTarget);
+            _caster.castAbility(spellTarget, 5, 0, 4, (float).25, 0, 0, false);
         }
         else if (abilityUsed == 5)
         {
-            _caster.ability5(spellTarget);
+            _caster.castAbility(spellTarget, 5, 0, 6, 0, 1, 0, true);
         }
+    }
 
+    //determines if the caster has enough ability points to cast a spell
+    public bool canCast(int abilityUsed)
+    {
+        if (abilityUsed == 1)
+        {
+            if (_caster._casterStatus.currentAction > 3 && spellTarget.currentHealth > 0)
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+        else if (abilityUsed == 2)
+        {
+            if (_caster._casterStatus.currentAction > 6 && spellTarget.currentHealth > 0)
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+        else if (abilityUsed == 3)
+        {
+            if (_caster._casterStatus.currentAction > 5 && spellTarget.currentHealth > 0)
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+        else if (abilityUsed == 4)
+        {
+            if (_caster._casterStatus.currentAction > 4 && spellTarget.currentHealth > 0)
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+        else if (abilityUsed == 5)
+        {
+            if (_caster._casterStatus.currentAction > 6 && spellTarget.currentHealth > 0)
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+        else
+        {
+            return false;
+        }
     }
 
 }

--- a/Assets/unityProject/Sprites/Spells/ImportedSpells/Magic_ring/magic_ring_01.prefab
+++ b/Assets/unityProject/Sprites/Spells/ImportedSpells/Magic_ring/magic_ring_01.prefab
@@ -6880,7 +6880,7 @@ ParticleSystem:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1578231811263146}
   serializedVersion: 5
-  lengthInSec: 5
+  lengthInSec: 7
   simulationSpeed: 1
   stopAction: 0
   looping: 0

--- a/Assets/unityProject/Sprites/Spells/ImportedSpells/Magic_ring/magic_ring_02.prefab
+++ b/Assets/unityProject/Sprites/Spells/ImportedSpells/Magic_ring/magic_ring_02.prefab
@@ -6904,7 +6904,7 @@ ParticleSystem:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1787567818718692}
   serializedVersion: 5
-  lengthInSec: 5
+  lengthInSec: 7
   simulationSpeed: 1
   stopAction: 0
   looping: 1

--- a/Assets/unityProject/Sprites/Spells/ImportedSpells/Magic_ring/magic_ring_03.prefab
+++ b/Assets/unityProject/Sprites/Spells/ImportedSpells/Magic_ring/magic_ring_03.prefab
@@ -6958,7 +6958,7 @@ ParticleSystem:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1859539564335096}
   serializedVersion: 5
-  lengthInSec: 5
+  lengthInSec: 7
   simulationSpeed: 1
   stopAction: 0
   looping: 0

--- a/Assets/unityProject/Sprites/Spells/ImportedSpells/Magic_ring/magic_ring_04.prefab
+++ b/Assets/unityProject/Sprites/Spells/ImportedSpells/Magic_ring/magic_ring_04.prefab
@@ -6934,7 +6934,7 @@ ParticleSystem:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1827459559325698}
   serializedVersion: 5
-  lengthInSec: 5
+  lengthInSec: 7
   simulationSpeed: 1
   stopAction: 0
   looping: 0

--- a/Assets/unityProject/Sprites/Spells/ImportedSpells/Magic_ring/magic_ring_05.prefab
+++ b/Assets/unityProject/Sprites/Spells/ImportedSpells/Magic_ring/magic_ring_05.prefab
@@ -203,7 +203,7 @@ ParticleSystem:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1750961381190182}
   serializedVersion: 5
-  lengthInSec: 5
+  lengthInSec: 7
   simulationSpeed: 1
   stopAction: 0
   looping: 0

--- a/Assets/unityProject/Sprites/Spells/ImportedSpells/Magic_ring/magic_ring_06.prefab
+++ b/Assets/unityProject/Sprites/Spells/ImportedSpells/Magic_ring/magic_ring_06.prefab
@@ -6958,7 +6958,7 @@ ParticleSystem:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1380636114508594}
   serializedVersion: 5
-  lengthInSec: 5
+  lengthInSec: 7
   simulationSpeed: 1
   stopAction: 0
   looping: 0


### PR DESCRIPTION
moved spell creation from Abilities.c to CastSpell.cs which allows me to prevent spell animations from casting when the target is dead or the caster lacks the required ability points